### PR TITLE
Update readme for WordPress 5.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,18 +1,23 @@
 === LatitudePay & Genoapay Integrations for WooCommerce ===
-Plugin URI: https://www.latitudefinancial.com.au/
-Description: An online ecommerce payment solution
-Version: 2.0.8
-License: GPLv2
+Tags: latitudepay, genoapay, woocommerce, bnpl, buynowpaylater
 Requires at least: 4.4
-Tested up to: 5.7
-Stable tag: 4.5.0
+Tested up to: 5.8
+Stable tag: 2.0.9
 Requires PHP: 5.6
+License: GPLv2
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Provides LatitudePay and Genoapay payment option for WooCommerce.
 
 == Description ==
-LatitudePay/Genoapay BNPL payment plugin for WooCommerce provides a seamless integration between your store and LatitudePay in Australia or Genoapay in New Zealand . LatitudePay is enabled automatically if the currency is set as Australian Dollars and Genoapay is enabled if the currency is set as New Zealand Dollars. It also enables the price point snippets on product display pages. There are zero surprises with LatitudePay & Genoapay. It does what it says on the box: 10 weekly payments instead of all at once. No interest, and no waiting for your purchases.
+LatitudePay/Genoapay Buy Now Pay Later (BNPL) payment plugin for WooCommerce provides a seamless integration between your store and LatitudePay in Australia or Genoapay in New Zealand. LatitudePay is enabled automatically if the currency is set as Australian Dollars and Genoapay is enabled if the currency is set as New Zealand Dollars. It also enables the price point snippets on product display pages. There are zero surprises with LatitudePay & Genoapay. It does what it says on the box: 10 weekly payments instead of all at once. No interest, and no waiting for your purchases.
+
+== Installation ==
+
+Please refer to our [latest installation guide](https://resources.latitudefinancial.com/docs/latitude-pay/woocommerce/).
 
 == Frequently Asked Questions ==
-= where do I find more information about LatitudePay and Genoapay? =
+= Where do I find more information about LatitudePay and Genoapay? =
 
 Please visit the official websites below for more information.
 [LatitudePay (Australia)](https://latitudepay.com)
@@ -22,43 +27,37 @@ Please visit the official websites below for more information.
 
 Please send your integration related issues to [Integration Support](mailto:integrationsupport@latitudefinancial.com)
 
-
 == Changelog ==
-
-= 2.0 =
-
-* Performance improvements.
-* Fixed shopping cart errors in some installations.
-* Changed min & max comparing methods.
-* Use get_data for all product types.
-
-= 2.0.2 =
-
-* Fix invalid signature issue
-
-= 2.0.3 =
-
-* Add configurations to toggle (opt-in / opt-out) payment snippets at product and cart pages
-* Fix style issue on Genoapay popup
-
-= 2.0.4 =
-
-* Fix conflicts issue with paypal
-* Fix other small bugs.
-
-= 2.0.5 =
-* Fix the conflict that cause empty cart issue
-
-= 2.0.6 =
-* Fix the style issue in Latitude popup
-
-= 2.0.7 =
-* Fix deprecated functions in new PHP version issue
-
-= 2.0.8 =
-* Fix invalid signature issue by replace all symbols from products' name by spaces
 
 = 2.0.9 =
 * Implement Images API snippets and modals
 * Improve logging function
 
+= 2.0.8 =
+* Fix invalid signature issue by replace all symbols from products' name by spaces
+
+= 2.0.7 =
+* Fix deprecated functions in new PHP version issue
+
+= 2.0.6 =
+* Fix the style issue in Latitude popup
+
+= 2.0.5 =
+* Fix the conflict that cause empty cart issue
+
+= 2.0.4 =
+* Fix conflicts issue with paypal
+* Fix other small bugs.
+
+= 2.0.3 =
+* Add configurations to toggle (opt-in / opt-out) payment snippets at product and cart pages
+* Fix style issue on Genoapay popup
+
+= 2.0.2 =
+* Fix invalid signature issue
+
+= 2.0 =
+* Performance improvements.
+* Fixed shopping cart errors in some installations.
+* Changed min & max comparing methods.
+* Use get_data for all product types.


### PR DESCRIPTION
Update readme to conform with WordPress plugin readme file standard.
https://wordpress.org/plugins/developers/#readme